### PR TITLE
Generate api client from openapi.yml

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,5 +23,6 @@
     "plugins": ["react", "@typescript-eslint"],
     "rules": {
         "react/react-in-jsx-scope": "off"
-    }
+    },
+    "ignorePatterns": ["src/api/generatedClient.ts"]
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,6 @@ jobs:
                   node-version: ${{ matrix.node-version }}
                   cache: npm
             - run: npm install
+            - run: npm run generate-api-client
             - run: npm run build
             - run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
 
         steps:
             - uses: actions/checkout@v2
+              with:
+                  submodules: true
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v2
               with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,11 +34,74 @@
                 "autoprefixer": "^10.4.0",
                 "eslint": "^8.7.0",
                 "eslint-plugin-react": "^7.28.0",
+                "oazapfts": "^3.5.0",
                 "postcss": "^8.4.5",
                 "prettier": "^2.5.1",
                 "react-scripts": "5.0.0",
                 "tailwindcss": "^3.0.8",
                 "typescript": "^4.5.5"
+            }
+        },
+        "node_modules/@apidevtools/json-schema-ref-parser": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+            "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+            "dev": true,
+            "dependencies": {
+                "@jsdevtools/ono": "^7.1.3",
+                "@types/json-schema": "^7.0.6",
+                "call-me-maybe": "^1.0.1",
+                "js-yaml": "^4.1.0"
+            }
+        },
+        "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
+        },
+        "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/@apidevtools/openapi-schemas": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+            "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@apidevtools/swagger-methods": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+            "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+            "dev": true
+        },
+        "node_modules/@apidevtools/swagger-parser": {
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+            "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+            "dev": true,
+            "dependencies": {
+                "@apidevtools/json-schema-ref-parser": "^9.0.6",
+                "@apidevtools/openapi-schemas": "^2.0.4",
+                "@apidevtools/swagger-methods": "^3.0.2",
+                "@jsdevtools/ono": "^7.1.3",
+                "call-me-maybe": "^1.0.1",
+                "z-schema": "^5.0.1"
+            },
+            "peerDependencies": {
+                "openapi-types": ">=7"
             }
         },
         "node_modules/@aws-amplify/analytics": {
@@ -6762,6 +6825,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@exodus/schemasafe": {
+            "version": "1.0.0-rc.6",
+            "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.6.tgz",
+            "integrity": "sha512-dDnQizD94EdBwEj/fh3zPRa/HWCS9O5au2PuHhZBbuM3xWHxuaKzPBOEWze7Nn0xW68MIpZ7Xdyn1CoCpjKCuQ==",
+            "dev": true
+        },
         "node_modules/@hapi/hoek": {
             "version": "9.2.1",
             "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
@@ -7528,6 +7597,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/@jsdevtools/ono": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+            "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+            "dev": true
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -12401,6 +12476,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/call-me-maybe": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+            "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+            "dev": true
+        },
         "node_modules/caller-callsite": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -14387,6 +14468,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/es6-promise": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+            "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+            "dev": true
+        },
         "node_modules/escalade": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -15605,6 +15692,12 @@
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
         },
+        "node_modules/fast-safe-stringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+            "dev": true
+        },
         "node_modules/fast-xml-parser": {
             "version": "3.21.1",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
@@ -16821,6 +16914,12 @@
             "engines": {
                 "node": ">=12.0.0"
             }
+        },
+        "node_modules/http2-client": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
+            "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
+            "dev": true
         },
         "node_modules/https-proxy-agent": {
             "version": "5.0.0",
@@ -20097,6 +20196,12 @@
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
             "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
         },
+        "node_modules/lodash.isequal": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+            "dev": true
+        },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -22106,6 +22211,18 @@
                 }
             }
         },
+        "node_modules/node-fetch-h2": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
+            "integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
+            "dev": true,
+            "dependencies": {
+                "http2-client": "^1.2.5"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            }
+        },
         "node_modules/node-fetch/node_modules/tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -22138,6 +22255,15 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
             "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+        },
+        "node_modules/node-readfiles": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
+            "integrity": "sha1-271K8SE04uY1wkXvk//Pb2BnOl0=",
+            "dev": true,
+            "dependencies": {
+                "es6-promise": "^3.2.1"
+            }
         },
         "node_modules/node-releases": {
             "version": "2.0.1",
@@ -22220,6 +22346,119 @@
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
             "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
             "dev": true
+        },
+        "node_modules/oas-kit-common": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
+            "integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
+            "dev": true,
+            "dependencies": {
+                "fast-safe-stringify": "^2.0.7"
+            }
+        },
+        "node_modules/oas-linter": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.2.2.tgz",
+            "integrity": "sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==",
+            "dev": true,
+            "dependencies": {
+                "@exodus/schemasafe": "^1.0.0-rc.2",
+                "should": "^13.2.1",
+                "yaml": "^1.10.0"
+            },
+            "funding": {
+                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+            }
+        },
+        "node_modules/oas-resolver": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
+            "integrity": "sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==",
+            "dev": true,
+            "dependencies": {
+                "node-fetch-h2": "^2.3.0",
+                "oas-kit-common": "^1.0.8",
+                "reftools": "^1.1.9",
+                "yaml": "^1.10.0",
+                "yargs": "^17.0.1"
+            },
+            "bin": {
+                "resolve": "resolve.js"
+            },
+            "funding": {
+                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+            }
+        },
+        "node_modules/oas-resolver/node_modules/yargs": {
+            "version": "17.3.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+            "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+            "dev": true,
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/oas-resolver/node_modules/yargs-parser": {
+            "version": "21.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+            "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/oas-schema-walker": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
+            "integrity": "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+            }
+        },
+        "node_modules/oas-validator": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.8.tgz",
+            "integrity": "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==",
+            "dev": true,
+            "dependencies": {
+                "call-me-maybe": "^1.0.1",
+                "oas-kit-common": "^1.0.8",
+                "oas-linter": "^3.2.2",
+                "oas-resolver": "^2.5.6",
+                "oas-schema-walker": "^1.1.5",
+                "reftools": "^1.1.9",
+                "should": "^13.2.1",
+                "yaml": "^1.10.0"
+            },
+            "funding": {
+                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+            }
+        },
+        "node_modules/oazapfts": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/oazapfts/-/oazapfts-3.5.0.tgz",
+            "integrity": "sha512-8UpGgfQZadfuRwEIz9NPXVHaXWPtWSkNfqabyJbnxVpCXDZVn8orcbrUn0lVDzjjpXEY9eOI2mwecTxxGWPNpA==",
+            "dev": true,
+            "dependencies": {
+                "@apidevtools/swagger-parser": "^10.0.1",
+                "lodash": "^4.17.20",
+                "minimist": "^1.2.5",
+                "swagger2openapi": "^7.0.7",
+                "typescript": "^4.1.2"
+            },
+            "bin": {
+                "oazapfts": "lib/codegen/cli.js"
+            }
         },
         "node_modules/ob1": {
             "version": "0.66.2",
@@ -22544,6 +22783,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/openapi-types": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-10.0.0.tgz",
+            "integrity": "sha512-Y8xOCT2eiKGYDzMW9R4x5cmfc3vGaaI4EL2pwhDmodWw1HlK18YcZ4uJxc7Rdp7/gGzAygzH9SXr6GKYIXbRcQ==",
+            "dev": true,
+            "peer": true
         },
         "node_modules/optionator": {
             "version": "0.9.1",
@@ -25355,6 +25601,15 @@
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
             "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
         },
+        "node_modules/reftools": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
+            "integrity": "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+            }
+        },
         "node_modules/regenerate": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -26501,6 +26756,60 @@
             "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
             "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="
         },
+        "node_modules/should": {
+            "version": "13.2.3",
+            "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+            "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+            "dev": true,
+            "dependencies": {
+                "should-equal": "^2.0.0",
+                "should-format": "^3.0.3",
+                "should-type": "^1.4.0",
+                "should-type-adaptors": "^1.0.1",
+                "should-util": "^1.0.0"
+            }
+        },
+        "node_modules/should-equal": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+            "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+            "dev": true,
+            "dependencies": {
+                "should-type": "^1.4.0"
+            }
+        },
+        "node_modules/should-format": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+            "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+            "dev": true,
+            "dependencies": {
+                "should-type": "^1.3.0",
+                "should-type-adaptors": "^1.0.1"
+            }
+        },
+        "node_modules/should-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+            "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+            "dev": true
+        },
+        "node_modules/should-type-adaptors": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+            "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+            "dev": true,
+            "dependencies": {
+                "should-type": "^1.3.0",
+                "should-util": "^1.0.0"
+            }
+        },
+        "node_modules/should-util": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+            "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
+            "dev": true
+        },
         "node_modules/side-channel": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -27626,6 +27935,60 @@
             "dev": true,
             "dependencies": {
                 "boolbase": "~1.0.0"
+            }
+        },
+        "node_modules/swagger2openapi": {
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
+            "integrity": "sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==",
+            "dev": true,
+            "dependencies": {
+                "call-me-maybe": "^1.0.1",
+                "node-fetch": "^2.6.1",
+                "node-fetch-h2": "^2.3.0",
+                "node-readfiles": "^0.2.0",
+                "oas-kit-common": "^1.0.8",
+                "oas-resolver": "^2.5.6",
+                "oas-schema-walker": "^1.1.5",
+                "oas-validator": "^5.0.8",
+                "reftools": "^1.1.9",
+                "yaml": "^1.10.0",
+                "yargs": "^17.0.1"
+            },
+            "bin": {
+                "boast": "boast.js",
+                "oas-validate": "oas-validate.js",
+                "swagger2openapi": "swagger2openapi.js"
+            },
+            "funding": {
+                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+            }
+        },
+        "node_modules/swagger2openapi/node_modules/yargs": {
+            "version": "17.3.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+            "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+            "dev": true,
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/swagger2openapi/node_modules/yargs-parser": {
+            "version": "21.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+            "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/symbol-tree": {
@@ -28828,6 +29191,15 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/validator": {
+            "version": "13.7.0",
+            "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+            "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/vary": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -29916,6 +30288,33 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/z-schema": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.2.tgz",
+            "integrity": "sha512-40TH47ukMHq5HrzkeVE40Ad7eIDKaRV2b+Qpi2prLc9X9eFJFzV7tMe5aH12e6avaSS/u5l653EQOv+J9PirPw==",
+            "dev": true,
+            "dependencies": {
+                "lodash.get": "^4.4.2",
+                "lodash.isequal": "^4.5.0",
+                "validator": "^13.7.0"
+            },
+            "bin": {
+                "z-schema": "bin/z-schema"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "commander": "^2.7.1"
+            }
+        },
+        "node_modules/z-schema/node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true,
+            "optional": true
+        },
         "node_modules/zen-observable": {
             "version": "0.8.15",
             "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
@@ -29950,6 +30349,61 @@
         }
     },
     "dependencies": {
+        "@apidevtools/json-schema-ref-parser": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+            "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+            "dev": true,
+            "requires": {
+                "@jsdevtools/ono": "^7.1.3",
+                "@types/json-schema": "^7.0.6",
+                "call-me-maybe": "^1.0.1",
+                "js-yaml": "^4.1.0"
+            },
+            "dependencies": {
+                "argparse": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+                    "dev": true
+                },
+                "js-yaml": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+                    "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "^2.0.1"
+                    }
+                }
+            }
+        },
+        "@apidevtools/openapi-schemas": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+            "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+            "dev": true
+        },
+        "@apidevtools/swagger-methods": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+            "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+            "dev": true
+        },
+        "@apidevtools/swagger-parser": {
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+            "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+            "dev": true,
+            "requires": {
+                "@apidevtools/json-schema-ref-parser": "^9.0.6",
+                "@apidevtools/openapi-schemas": "^2.0.4",
+                "@apidevtools/swagger-methods": "^3.0.2",
+                "@jsdevtools/ono": "^7.1.3",
+                "call-me-maybe": "^1.0.1",
+                "z-schema": "^5.0.1"
+            }
+        },
         "@aws-amplify/analytics": {
             "version": "5.1.9",
             "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-5.1.9.tgz",
@@ -35568,6 +36022,12 @@
                 }
             }
         },
+        "@exodus/schemasafe": {
+            "version": "1.0.0-rc.6",
+            "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.6.tgz",
+            "integrity": "sha512-dDnQizD94EdBwEj/fh3zPRa/HWCS9O5au2PuHhZBbuM3xWHxuaKzPBOEWze7Nn0xW68MIpZ7Xdyn1CoCpjKCuQ==",
+            "dev": true
+        },
         "@hapi/hoek": {
             "version": "9.2.1",
             "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
@@ -36149,6 +36609,12 @@
                     }
                 }
             }
+        },
+        "@jsdevtools/ono": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+            "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+            "dev": true
         },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -39902,6 +40368,12 @@
                 "get-intrinsic": "^1.0.2"
             }
         },
+        "call-me-maybe": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+            "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+            "dev": true
+        },
         "caller-callsite": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -41440,6 +41912,12 @@
                 "is-symbol": "^1.0.2"
             }
         },
+        "es6-promise": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+            "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+            "dev": true
+        },
         "escalade": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -42364,6 +42842,12 @@
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
         },
+        "fast-safe-stringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+            "dev": true
+        },
         "fast-xml-parser": {
             "version": "3.21.1",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
@@ -43273,6 +43757,12 @@
                 "is-plain-obj": "^3.0.0",
                 "micromatch": "^4.0.2"
             }
+        },
+        "http2-client": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
+            "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
+            "dev": true
         },
         "https-proxy-agent": {
             "version": "5.0.0",
@@ -45718,6 +46208,12 @@
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
             "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
         },
+        "lodash.isequal": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+            "dev": true
+        },
         "lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -47375,6 +47871,15 @@
                 }
             }
         },
+        "node-fetch-h2": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
+            "integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
+            "dev": true,
+            "requires": {
+                "http2-client": "^1.2.5"
+            }
+        },
         "node-forge": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
@@ -47385,6 +47890,15 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
             "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+        },
+        "node-readfiles": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
+            "integrity": "sha1-271K8SE04uY1wkXvk//Pb2BnOl0=",
+            "dev": true,
+            "requires": {
+                "es6-promise": "^3.2.1"
+            }
         },
         "node-releases": {
             "version": "2.0.1",
@@ -47442,6 +47956,97 @@
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
             "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
             "dev": true
+        },
+        "oas-kit-common": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
+            "integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
+            "dev": true,
+            "requires": {
+                "fast-safe-stringify": "^2.0.7"
+            }
+        },
+        "oas-linter": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.2.2.tgz",
+            "integrity": "sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==",
+            "dev": true,
+            "requires": {
+                "@exodus/schemasafe": "^1.0.0-rc.2",
+                "should": "^13.2.1",
+                "yaml": "^1.10.0"
+            }
+        },
+        "oas-resolver": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
+            "integrity": "sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==",
+            "dev": true,
+            "requires": {
+                "node-fetch-h2": "^2.3.0",
+                "oas-kit-common": "^1.0.8",
+                "reftools": "^1.1.9",
+                "yaml": "^1.10.0",
+                "yargs": "^17.0.1"
+            },
+            "dependencies": {
+                "yargs": {
+                    "version": "17.3.1",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+                    "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^7.0.2",
+                        "escalade": "^3.1.1",
+                        "get-caller-file": "^2.0.5",
+                        "require-directory": "^2.1.1",
+                        "string-width": "^4.2.3",
+                        "y18n": "^5.0.5",
+                        "yargs-parser": "^21.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "21.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+                    "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+                    "dev": true
+                }
+            }
+        },
+        "oas-schema-walker": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
+            "integrity": "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==",
+            "dev": true
+        },
+        "oas-validator": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.8.tgz",
+            "integrity": "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==",
+            "dev": true,
+            "requires": {
+                "call-me-maybe": "^1.0.1",
+                "oas-kit-common": "^1.0.8",
+                "oas-linter": "^3.2.2",
+                "oas-resolver": "^2.5.6",
+                "oas-schema-walker": "^1.1.5",
+                "reftools": "^1.1.9",
+                "should": "^13.2.1",
+                "yaml": "^1.10.0"
+            }
+        },
+        "oazapfts": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/oazapfts/-/oazapfts-3.5.0.tgz",
+            "integrity": "sha512-8UpGgfQZadfuRwEIz9NPXVHaXWPtWSkNfqabyJbnxVpCXDZVn8orcbrUn0lVDzjjpXEY9eOI2mwecTxxGWPNpA==",
+            "dev": true,
+            "requires": {
+                "@apidevtools/swagger-parser": "^10.0.1",
+                "lodash": "^4.17.20",
+                "minimist": "^1.2.5",
+                "swagger2openapi": "^7.0.7",
+                "typescript": "^4.1.2"
+            }
         },
         "ob1": {
             "version": "0.66.2",
@@ -47677,6 +48282,13 @@
                 "is-docker": "^2.1.1",
                 "is-wsl": "^2.2.0"
             }
+        },
+        "openapi-types": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-10.0.0.tgz",
+            "integrity": "sha512-Y8xOCT2eiKGYDzMW9R4x5cmfc3vGaaI4EL2pwhDmodWw1HlK18YcZ4uJxc7Rdp7/gGzAygzH9SXr6GKYIXbRcQ==",
+            "dev": true,
+            "peer": true
         },
         "optionator": {
             "version": "0.9.1",
@@ -49628,6 +50240,12 @@
                 }
             }
         },
+        "reftools": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
+            "integrity": "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==",
+            "dev": true
+        },
         "regenerate": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -50514,6 +51132,60 @@
             "version": "1.7.3",
             "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
             "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="
+        },
+        "should": {
+            "version": "13.2.3",
+            "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+            "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+            "dev": true,
+            "requires": {
+                "should-equal": "^2.0.0",
+                "should-format": "^3.0.3",
+                "should-type": "^1.4.0",
+                "should-type-adaptors": "^1.0.1",
+                "should-util": "^1.0.0"
+            }
+        },
+        "should-equal": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+            "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+            "dev": true,
+            "requires": {
+                "should-type": "^1.4.0"
+            }
+        },
+        "should-format": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+            "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+            "dev": true,
+            "requires": {
+                "should-type": "^1.3.0",
+                "should-type-adaptors": "^1.0.1"
+            }
+        },
+        "should-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+            "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+            "dev": true
+        },
+        "should-type-adaptors": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+            "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+            "dev": true,
+            "requires": {
+                "should-type": "^1.3.0",
+                "should-util": "^1.0.0"
+            }
+        },
+        "should-util": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+            "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
+            "dev": true
         },
         "side-channel": {
             "version": "1.0.4",
@@ -51423,6 +52095,48 @@
                     "requires": {
                         "boolbase": "~1.0.0"
                     }
+                }
+            }
+        },
+        "swagger2openapi": {
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
+            "integrity": "sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==",
+            "dev": true,
+            "requires": {
+                "call-me-maybe": "^1.0.1",
+                "node-fetch": "^2.6.1",
+                "node-fetch-h2": "^2.3.0",
+                "node-readfiles": "^0.2.0",
+                "oas-kit-common": "^1.0.8",
+                "oas-resolver": "^2.5.6",
+                "oas-schema-walker": "^1.1.5",
+                "oas-validator": "^5.0.8",
+                "reftools": "^1.1.9",
+                "yaml": "^1.10.0",
+                "yargs": "^17.0.1"
+            },
+            "dependencies": {
+                "yargs": {
+                    "version": "17.3.1",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+                    "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^7.0.2",
+                        "escalade": "^3.1.1",
+                        "get-caller-file": "^2.0.5",
+                        "require-directory": "^2.1.1",
+                        "string-width": "^4.2.3",
+                        "y18n": "^5.0.5",
+                        "yargs-parser": "^21.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "21.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+                    "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+                    "dev": true
                 }
             }
         },
@@ -52350,6 +53064,12 @@
                 }
             }
         },
+        "validator": {
+            "version": "13.7.0",
+            "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+            "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+            "dev": true
+        },
         "vary": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -53213,6 +53933,27 @@
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true
+        },
+        "z-schema": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.2.tgz",
+            "integrity": "sha512-40TH47ukMHq5HrzkeVE40Ad7eIDKaRV2b+Qpi2prLc9X9eFJFzV7tMe5aH12e6avaSS/u5l653EQOv+J9PirPw==",
+            "dev": true,
+            "requires": {
+                "commander": "^2.7.1",
+                "lodash.get": "^4.4.2",
+                "lodash.isequal": "^4.5.0",
+                "validator": "^13.7.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.20.3",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
         },
         "zen-observable": {
             "version": "0.8.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
                 "prettier": "^2.5.1",
                 "react-scripts": "5.0.0",
                 "tailwindcss": "^3.0.8",
+                "ts-node": "^10.4.0",
                 "typescript": "^4.5.5"
             }
         },
@@ -6578,6 +6579,27 @@
                 "node": ">=0.1.95"
             }
         },
+        "node_modules/@cspotcode/source-map-consumer": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+            "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+            "devOptional": true,
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/@cspotcode/source-map-support": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+            "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+            "devOptional": true,
+            "dependencies": {
+                "@cspotcode/source-map-consumer": "0.8.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/@csstools/normalize.css": {
             "version": "12.0.0",
             "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
@@ -10067,6 +10089,30 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/@tsconfig/node10": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+            "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+            "devOptional": true
+        },
+        "node_modules/@tsconfig/node12": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+            "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+            "devOptional": true
+        },
+        "node_modules/@tsconfig/node14": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+            "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+            "devOptional": true
+        },
+        "node_modules/@tsconfig/node16": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+            "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+            "devOptional": true
+        },
         "node_modules/@types/aria-query": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
@@ -11115,7 +11161,7 @@
             "version": "8.7.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
             "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-            "dev": true,
+            "devOptional": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -13312,6 +13358,12 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "devOptional": true
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
@@ -20499,6 +20551,12 @@
             "bin": {
                 "semver": "bin/semver.js"
             }
+        },
+        "node_modules/make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+            "devOptional": true
         },
         "node_modules/makeerror": {
             "version": "1.0.12",
@@ -28478,6 +28536,71 @@
             "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
             "dev": true
         },
+        "node_modules/ts-node": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+            "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+            "devOptional": true,
+            "dependencies": {
+                "@cspotcode/source-map-support": "0.7.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "yn": "3.1.1"
+            },
+            "bin": {
+                "ts-node": "dist/bin.js",
+                "ts-node-cwd": "dist/bin-cwd.js",
+                "ts-node-script": "dist/bin-script.js",
+                "ts-node-transpile-only": "dist/bin-transpile.js",
+                "ts-script": "dist/bin-script-deprecated.js"
+            },
+            "peerDependencies": {
+                "@swc/core": ">=1.2.50",
+                "@swc/wasm": ">=1.2.50",
+                "@types/node": "*",
+                "typescript": ">=2.7"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/wasm": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ts-node/node_modules/acorn-walk": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+            "devOptional": true,
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/ts-node/node_modules/arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+            "devOptional": true
+        },
+        "node_modules/ts-node/node_modules/diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "devOptional": true,
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
         "node_modules/tsconfig-paths": {
             "version": "3.12.0",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
@@ -28768,7 +28891,7 @@
             "version": "4.5.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
             "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-            "dev": true,
+            "devOptional": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -30274,6 +30397,15 @@
             "dev": true,
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "devOptional": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/yocto-queue": {
@@ -35826,6 +35958,21 @@
                 "minimist": "^1.2.0"
             }
         },
+        "@cspotcode/source-map-consumer": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+            "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+            "devOptional": true
+        },
+        "@cspotcode/source-map-support": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+            "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+            "devOptional": true,
+            "requires": {
+                "@cspotcode/source-map-consumer": "0.8.0"
+            }
+        },
         "@csstools/normalize.css": {
             "version": "12.0.0",
             "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
@@ -38461,6 +38608,30 @@
             "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
             "dev": true
         },
+        "@tsconfig/node10": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+            "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+            "devOptional": true
+        },
+        "@tsconfig/node12": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+            "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+            "devOptional": true
+        },
+        "@tsconfig/node14": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+            "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+            "devOptional": true
+        },
+        "@tsconfig/node16": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+            "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+            "devOptional": true
+        },
         "@types/aria-query": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
@@ -39297,7 +39468,7 @@
             "version": "8.7.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
             "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-            "dev": true
+            "devOptional": true
         },
         "acorn-globals": {
             "version": "6.0.0",
@@ -41038,6 +41209,12 @@
                 "path-type": "^4.0.0",
                 "yaml": "^1.10.0"
             }
+        },
+        "create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "devOptional": true
         },
         "cross-spawn": {
             "version": "7.0.3",
@@ -46455,6 +46632,12 @@
                     "dev": true
                 }
             }
+        },
+        "make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+            "devOptional": true
         },
         "makeerror": {
             "version": "1.0.12",
@@ -52504,6 +52687,46 @@
             "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
             "dev": true
         },
+        "ts-node": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+            "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+            "devOptional": true,
+            "requires": {
+                "@cspotcode/source-map-support": "0.7.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "yn": "3.1.1"
+            },
+            "dependencies": {
+                "acorn-walk": {
+                    "version": "8.2.0",
+                    "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+                    "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+                    "devOptional": true
+                },
+                "arg": {
+                    "version": "4.1.3",
+                    "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+                    "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+                    "devOptional": true
+                },
+                "diff": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+                    "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+                    "devOptional": true
+                }
+            }
+        },
         "tsconfig-paths": {
             "version": "3.12.0",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
@@ -52739,7 +52962,7 @@
             "version": "4.5.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
             "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-            "dev": true
+            "devOptional": true
         },
         "uglify-es": {
             "version": "3.3.9",
@@ -53927,6 +54150,12 @@
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
             "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
             "dev": true
+        },
+        "yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "devOptional": true
         },
         "yocto-queue": {
             "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "autoprefixer": "^10.4.0",
         "eslint": "^8.7.0",
         "eslint-plugin-react": "^7.28.0",
+        "oazapfts": "^3.5.0",
         "postcss": "^8.4.5",
         "prettier": "^2.5.1",
         "react-scripts": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
         "start": "react-scripts start",
         "build": "react-scripts build",
         "test": "react-scripts test",
-        "eject": "react-scripts eject"
+        "eject": "react-scripts eject",
+        "generate-api-client": "ts-node -O '{\"module\":\"commonjs\"}' ./scripts/generate-api-client.ts"
     },
     "browserslist": {
         "production": [

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "prettier": "^2.5.1",
         "react-scripts": "5.0.0",
         "tailwindcss": "^3.0.8",
+        "ts-node": "^10.4.0",
         "typescript": "^4.5.5"
     },
     "babelMacros": {

--- a/scripts/generate-api-client.ts
+++ b/scripts/generate-api-client.ts
@@ -1,9 +1,22 @@
 import { spawnSync } from "child_process";
 
-const GENERATED_FILEPATH = 'src/api/generatedClient.ts';
+const main = () => {
+    runNpxCommand(`oazapfts ./bnomial/openapi.yml ${GENERATED_FILEPATH} --optimistic`);
+
+    const { stdout } = spawnSync("git", ["status"]);
+
+    if (stdout.toString().includes(GENERATED_FILEPATH)) {
+        console.error(
+            `${GENERATED_FILEPATH} is not up to date. Please run "npm run generate-api-client" and commit the changes.`
+        );
+        process.exit(1);
+    }
+};
+
+const GENERATED_FILEPATH = "src/api/generatedClient.ts";
 
 const runNpxCommand = (command: string) => {
-    const { status } = spawnSync("npx", command.split(' '), {
+    const { status } = spawnSync("npx", command.split(" "), {
         stdio: "inherit",
     });
     if (status !== 0) {
@@ -11,11 +24,6 @@ const runNpxCommand = (command: string) => {
     }
 };
 
-runNpxCommand(`oazapfts ./bnomial/openapi.yml ${GENERATED_FILEPATH} --optimistic`);
-
-const { stdout } = spawnSync("git", ["status"]);
-
-if (stdout.toString().includes(GENERATED_FILEPATH)) {
-  console.error(`${GENERATED_FILEPATH} is not up to date. Please run "npm run generate-api-client" and commit the changes.`);
-  process.exit(1);
+if (require.main === module) {
+    main();
 }

--- a/scripts/generate-api-client.ts
+++ b/scripts/generate-api-client.ts
@@ -3,9 +3,7 @@ import { spawnSync } from "child_process";
 const main = () => {
     generateApiClient();
 
-    const { stdout } = spawnSync("git", ["status"]);
-
-    if (stdout.toString().includes(GENERATED_FILEPATH)) {
+    if (!isApiClientUpToDate()) {
         console.error(
             `${GENERATED_FILEPATH} is not up to date. Please run "npm run generate-api-client" and commit the changes.`
         );
@@ -16,6 +14,11 @@ const main = () => {
 const generateApiClient = () => {
     runNpxCommand(`oazapfts ./bnomial/openapi.yml ${GENERATED_FILEPATH} --optimistic`);
     runNpxCommand(`prettier -w ${GENERATED_FILEPATH}`);
+};
+
+const isApiClientUpToDate = () => {
+    const { stdout } = spawnSync("git", ["status"]);
+    return !stdout.toString().includes(GENERATED_FILEPATH);
 };
 
 const GENERATED_FILEPATH = "src/api/generatedClient.ts";

--- a/scripts/generate-api-client.ts
+++ b/scripts/generate-api-client.ts
@@ -1,0 +1,9 @@
+import { spawnSync } from "child_process";
+
+const runNpxCommand = (command: string) => {
+    spawnSync("npx", command.split(' '), {
+        stdio: "inherit",
+    });
+};
+
+runNpxCommand("oazapfts ./bnomial/openapi.yml ./src/api/generatedClient.ts --optimistic");

--- a/scripts/generate-api-client.ts
+++ b/scripts/generate-api-client.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "child_process";
 
 const main = () => {
-    runNpxCommand(`oazapfts ./bnomial/openapi.yml ${GENERATED_FILEPATH} --optimistic`);
+    generateApiClient();
 
     const { stdout } = spawnSync("git", ["status"]);
 
@@ -11,6 +11,11 @@ const main = () => {
         );
         process.exit(1);
     }
+};
+
+const generateApiClient = () => {
+    runNpxCommand(`oazapfts ./bnomial/openapi.yml ${GENERATED_FILEPATH} --optimistic`);
+    runNpxCommand(`prettier -w ${GENERATED_FILEPATH}`);
 };
 
 const GENERATED_FILEPATH = "src/api/generatedClient.ts";

--- a/scripts/generate-api-client.ts
+++ b/scripts/generate-api-client.ts
@@ -1,9 +1,18 @@
 import { spawnSync } from "child_process";
 
+const GENERATED_FILEPATH = 'src/api/generatedClient.ts';
+
 const runNpxCommand = (command: string) => {
     spawnSync("npx", command.split(' '), {
         stdio: "inherit",
     });
 };
 
-runNpxCommand("oazapfts ./bnomial/openapi.yml ./src/api/generatedClient.ts --optimistic");
+runNpxCommand(`oazapfts ./bnomial/openapi.yml ${GENERATED_FILEPATH} --optimistic`);
+
+const { stdout } = spawnSync("git", ["status"]);
+
+if (stdout.toString().includes(GENERATED_FILEPATH)) {
+  console.error(`${GENERATED_FILEPATH} is not up to date. Please run "npm run generate-api-client" and commit the changes.`);
+  process.exit(1);
+}

--- a/scripts/generate-api-client.ts
+++ b/scripts/generate-api-client.ts
@@ -3,9 +3,12 @@ import { spawnSync } from "child_process";
 const GENERATED_FILEPATH = 'src/api/generatedClient.ts';
 
 const runNpxCommand = (command: string) => {
-    spawnSync("npx", command.split(' '), {
+    const { status } = spawnSync("npx", command.split(' '), {
         stdio: "inherit",
     });
+    if (status !== 0) {
+        process.exit(status || 1);
+    }
 };
 
 runNpxCommand(`oazapfts ./bnomial/openapi.yml ${GENERATED_FILEPATH} --optimistic`);

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,6 @@
 import React from "react";
-import axios from "axios";
+
+import * as generatedClient from "./api/generatedClient";
 
 import { Question } from "./types";
 
@@ -22,14 +23,8 @@ export const useApiClient = () => {
 const BACKEND_URL = "https://hv2i83bavj.execute-api.us-east-1.amazonaws.com/prod";
 
 export const DefaultApiClient: ApiClient = {
-    getRandomQuestion: async () => {
-        const response = await axios.get(`${BACKEND_URL}/questions/random`);
-        return response.data as Question;
-    },
-    getSampleQuestions: async () => {
-        const response = await axios.get(`${BACKEND_URL}/public/sample`);
-        return response.data as Question[];
-    },
+    getRandomQuestion: async () => generatedClient.getRandomQuestion({ baseUrl: BACKEND_URL }),
+    getSampleQuestions: async () => generatedClient.getSampleQuestions({ baseUrl: BACKEND_URL }),
 };
 
 // This client can be used to mock the API for testing

--- a/src/api/generatedClient.ts
+++ b/src/api/generatedClient.ts
@@ -15,7 +15,9 @@ export type Question = {
     id: string;
     title: string;
     content: string;
-    choices: object;
+    choices: {
+        [key: string]: string;
+    };
 };
 /**
  * Return a list of questions from the public database of open questions.

--- a/src/api/generatedClient.ts
+++ b/src/api/generatedClient.ts
@@ -23,108 +23,149 @@ export type Question = {
  * Return a list of questions from the public database of open questions.
  */
 export function getSampleQuestions(opts?: Oazapfts.RequestOpts) {
-    return oazapfts.ok(oazapfts.fetchJson<{
-        status: 200;
-        data: Question[];
-    } | {
-        status: 500;
-        data: string;
-    }>("/public/sample", {
-        ...opts
-    }));
+    return oazapfts.ok(
+        oazapfts.fetchJson<
+            | {
+                  status: 200;
+                  data: Question[];
+              }
+            | {
+                  status: 500;
+                  data: string;
+              }
+        >("/public/sample", {
+            ...opts,
+        })
+    );
 }
 /**
  * Registers a new session with the service.
  */
-export function createSession(body: {
-    name?: string;
-    answers?: object;
-}, opts?: Oazapfts.RequestOpts) {
-    return oazapfts.ok(oazapfts.fetchText("/public/session", oazapfts.json({
-        ...opts,
-        method: "POST",
-        body
-    })));
+export function createSession(
+    body: {
+        name?: string;
+        answers?: object;
+    },
+    opts?: Oazapfts.RequestOpts
+) {
+    return oazapfts.ok(
+        oazapfts.fetchText(
+            "/public/session",
+            oazapfts.json({
+                ...opts,
+                method: "POST",
+                body,
+            })
+        )
+    );
 }
 /**
  * Return a question from the public database of questions.
  */
 export function getQuestion(questionId: string, opts?: Oazapfts.RequestOpts) {
-    return oazapfts.ok(oazapfts.fetchJson<{
-        status: 200;
-        data: Question;
-    } | {
-        status: 404;
-    } | {
-        status: 500;
-        data: string;
-    }>(`/questions/${questionId}`, {
-        ...opts
-    }));
+    return oazapfts.ok(
+        oazapfts.fetchJson<
+            | {
+                  status: 200;
+                  data: Question;
+              }
+            | {
+                  status: 404;
+              }
+            | {
+                  status: 500;
+                  data: string;
+              }
+        >(`/questions/${questionId}`, {
+            ...opts,
+        })
+    );
 }
 /**
  * Return a random question from the public database of open questions.
  */
 export function getRandomQuestion(opts?: Oazapfts.RequestOpts) {
-    return oazapfts.ok(oazapfts.fetchJson<{
-        status: 200;
-        data: Question;
-    } | {
-        status: 404;
-    } | {
-        status: 500;
-        data: string;
-    }>("/public/question/", {
-        ...opts
-    }));
+    return oazapfts.ok(
+        oazapfts.fetchJson<
+            | {
+                  status: 200;
+                  data: Question;
+              }
+            | {
+                  status: 404;
+              }
+            | {
+                  status: 500;
+                  data: string;
+              }
+        >("/public/question/", {
+            ...opts,
+        })
+    );
 }
 /**
  * Submit the answer to the specified question
  */
 export function answerQuestion(questionId: string, body: string[], opts?: Oazapfts.RequestOpts) {
-    return oazapfts.ok(oazapfts.fetchText(`/public/question/${questionId}`, oazapfts.json({
-        ...opts,
-        method: "POST",
-        body
-    })));
+    return oazapfts.ok(
+        oazapfts.fetchText(
+            `/public/question/${questionId}`,
+            oazapfts.json({
+                ...opts,
+                method: "POST",
+                body,
+            })
+        )
+    );
 }
 /**
  * Return the public leaderboard.
  */
 export function getLeaderboard(opts?: Oazapfts.RequestOpts) {
-    return oazapfts.ok(oazapfts.fetchJson<{
-        status: 200;
-        data: {
-            leaderboard?: {
-                id?: string;
-                name?: string;
-                score?: number;
-            }[];
-            rank?: number;
-        }[];
-    } | {
-        status: 500;
-        data: string;
-    }>("/public/leaderboard/", {
-        ...opts
-    }));
+    return oazapfts.ok(
+        oazapfts.fetchJson<
+            | {
+                  status: 200;
+                  data: {
+                      leaderboard?: {
+                          id?: string;
+                          name?: string;
+                          score?: number;
+                      }[];
+                      rank?: number;
+                  }[];
+              }
+            | {
+                  status: 500;
+                  data: string;
+              }
+        >("/public/leaderboard/", {
+            ...opts,
+        })
+    );
 }
 /**
  * Return the list of of practice questions from the public database
  */
 export function getPracticeQuestions(opts?: Oazapfts.RequestOpts) {
-    return oazapfts.ok(oazapfts.fetchJson<{
-        status: 200;
-        data: (Question & {
-            explanation: string;
-            answer: string[];
-        })[];
-    } | {
-        status: 404;
-    } | {
-        status: 500;
-        data: string;
-    }>("/practice/questions/", {
-        ...opts
-    }));
+    return oazapfts.ok(
+        oazapfts.fetchJson<
+            | {
+                  status: 200;
+                  data: (Question & {
+                      explanation: string;
+                      answer: string[];
+                  })[];
+              }
+            | {
+                  status: 404;
+              }
+            | {
+                  status: 500;
+                  data: string;
+              }
+        >("/practice/questions/", {
+            ...opts,
+        })
+    );
 }

--- a/src/api/generatedClient.ts
+++ b/src/api/generatedClient.ts
@@ -1,0 +1,128 @@
+/**
+ * Bnomial Service
+ * 1.0.0
+ * DO NOT MODIFY - This file has been generated using oazapfts.
+ * See https://www.npmjs.com/package/oazapfts
+ */
+import * as Oazapfts from "oazapfts/lib/runtime";
+import * as QS from "oazapfts/lib/runtime/query";
+export const defaults: Oazapfts.RequestOpts = {
+    baseUrl: "/",
+};
+const oazapfts = Oazapfts.runtime(defaults);
+export const servers = {};
+export type Question = {
+    id: string;
+    title: string;
+    content: string;
+    choices: object;
+};
+/**
+ * Return a list of questions from the public database of open questions.
+ */
+export function getSampleQuestions(opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: Question[];
+    } | {
+        status: 500;
+        data: string;
+    }>("/public/sample", {
+        ...opts
+    }));
+}
+/**
+ * Registers a new session with the service.
+ */
+export function createSession(body: {
+    name?: string;
+    answers?: object;
+}, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchText("/public/session", oazapfts.json({
+        ...opts,
+        method: "POST",
+        body
+    })));
+}
+/**
+ * Return a question from the public database of questions.
+ */
+export function getQuestion(questionId: string, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: Question;
+    } | {
+        status: 404;
+    } | {
+        status: 500;
+        data: string;
+    }>(`/questions/${questionId}`, {
+        ...opts
+    }));
+}
+/**
+ * Return a random question from the public database of open questions.
+ */
+export function getRandomQuestion(opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: Question;
+    } | {
+        status: 404;
+    } | {
+        status: 500;
+        data: string;
+    }>("/public/question/", {
+        ...opts
+    }));
+}
+/**
+ * Submit the answer to the specified question
+ */
+export function answerQuestion(questionId: string, body: string[], opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchText(`/public/question/${questionId}`, oazapfts.json({
+        ...opts,
+        method: "POST",
+        body
+    })));
+}
+/**
+ * Return the public leaderboard.
+ */
+export function getLeaderboard(opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: {
+            leaderboard?: {
+                id?: string;
+                name?: string;
+                score?: number;
+            }[];
+            rank?: number;
+        }[];
+    } | {
+        status: 500;
+        data: string;
+    }>("/public/leaderboard/", {
+        ...opts
+    }));
+}
+/**
+ * Return the list of of practice questions from the public database
+ */
+export function getPracticeQuestions(opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: (Question & {
+            explanation: string;
+            answer: string[];
+        })[];
+    } | {
+        status: 404;
+    } | {
+        status: 500;
+        data: string;
+    }>("/practice/questions/", {
+        ...opts
+    }));
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,8 +1,7 @@
 import React from "react";
 
-import * as generatedClient from "./api/generatedClient";
-
-import { Question } from "./types";
+import { Question } from "../types";
+import * as generatedClient from "./generatedClient";
 
 export interface ApiClient {
     getRandomQuestion: () => Promise<Question>;


### PR DESCRIPTION
- Added [oazapfts](https://github.com/cellular/oazapfts) as API generator
- Added a npm script command for generating the API client from the submodule's openapi.yml
  - After generation, it will also check whether the generated client has changed compared to the committed state and will exit with status code 1 (i.e. the submodule was updated without regenerating the API client)
  - Added this script also to the CI workflow which will fail the workflow if the latest API client is not committed
- Updated the naive implementation of the `DefaultApiClient` to one that uses the generated API client

Resolves #26 